### PR TITLE
Add build deps script

### DIFF
--- a/build-deps.sh
+++ b/build-deps.sh
@@ -11,4 +11,6 @@ if [ ${MACHINE_TYPE} == 'x86_64' ]; then
     apt-get install -y ia32-libs
     # Required for kernel cross compiles
     apt-get install -y libncurses5:i386
+else
+    apt-get install -y libncurses5
 fi


### PR DESCRIPTION
This adds a script to pull in the build dependencies required to build the Kali ARM images on 32bit or 64bit machines.
