### PR TITLE
Add sunxi_emac to /etc/modules so that eth0 shows up.

### DIFF
--- a/cubieboard2.sh
+++ b/cubieboard2.sh
@@ -183,6 +183,10 @@ fatload mmc 0 0x48000000 uImage
 bootm 0x48000000
 EOF
 
+cat << EOF >> ${basedir}/root/etc/modules
+sunxi_emac
+EOF
+
 # Create image
 mkimage -A arm -T script -C none -d ${basedir}/bootp/boot.cmd ${basedir}/bootp/boot.scr
 


### PR DESCRIPTION
The sunxi_emac module doesn't appear to have modinfo/modalias set up, so it doesn't modprobe automagically, so we add it to /etc/modules in order to have an eth0 device on the cubieboard2.

Signed-off-by: Steev Klimaszewski (Kali Developer) steev@kali.org
