### PR TITLE
remove doubled pixz installation

### DIFF
--- a/build-deps.sh
+++ b/build-deps.sh
@@ -2,7 +2,7 @@
 apt-get install -y git-core gnupg flex bison gperf libesd0-dev build-essential \
 zip curl libncurses5-dev zlib1g-dev libncurses5-dev gcc-multilib g++-multilib \
 parted kpartx debootstrap pixz qemu-user-static abootimg cgpt vboot-kernel-utils \
-vboot-utils u-boot-tools bc lzma lzop automake autoconf m4 dosfstools pixz rsync \
+vboot-utils u-boot-tools bc lzma lzop automake autoconf m4 dosfstools rsync \
 schedtool git dosfstools e2fsprogs device-tree-compiler libssl-dev btrfs-tools
 MACHINE_TYPE=`uname -m`
 if [ ${MACHINE_TYPE} == 'x86_64' ]; then


### PR DESCRIPTION
Just noticed that pixz was used twice in apt-get install