### PR TITLE
Fix bitrot in patches for rockchip-based chromebooks (veyron)

### DIFF
--- a/patches/0002-mwifiex-do-not-create-AP-and-P2P-interfaces-upon-dri.patch
+++ b/patches/0002-mwifiex-do-not-create-AP-and-P2P-interfaces-upon-dri.patch
@@ -38,26 +38,28 @@ diff --git a/drivers/net/wireless-3.8/mwifiex/main.c b/drivers/net/wireless-3.8/
 index b3f9247..a503264 100644
 --- a/drivers/net/wireless-3.8/mwifiex/main.c
 +++ b/drivers/net/wireless-3.8/mwifiex/main.c
-@@ -515,19 +515,6 @@ static void mwifiex_fw_dpc(const struct firmware *firmware, void *context)
- 		goto err_add_intf;
- 	}
+@@ -524,21 +524,6 @@ static void mwifiex_fw_dpc(const struct firmware *firmware, void *context)
+		goto err_add_intf;
+	}
  
 -	/* Create AP interface by default */
 -	if (!mwifiex_add_virtual_intf(adapter->wiphy, "uap%d",
 -				      NL80211_IFTYPE_AP, NULL, NULL)) {
--		dev_err(adapter->dev, "cannot create default AP interface\n");
+-		mwifiex_dbg(adapter, ERROR,
+-			    "cannot create default AP interface\n");
 -		goto err_add_intf;
 -	}
 -
 -	/* Create P2P interface by default */
 -	if (!mwifiex_add_virtual_intf(adapter->wiphy, "p2p%d",
 -				      NL80211_IFTYPE_P2P_CLIENT, NULL, NULL)) {
--		dev_err(adapter->dev, "cannot create default P2P interface\n");
+-		mwifiex_dbg(adapter, ERROR,
+-			    "cannot create default P2P interface\n");
 -		goto err_add_intf;
 -	}
- 	rtnl_unlock();
+	rtnl_unlock();
  
- 	mwifiex_drv_get_driver_version(adapter, fmt, sizeof(fmt) - 1);
+	mwifiex_drv_get_driver_version(adapter, fmt, sizeof(fmt) - 1);
 -- 
 2.4.4
 

--- a/patches/0004-fix-brcmfmac-oops-and-race-condition.patch
+++ b/patches/0004-fix-brcmfmac-oops-and-race-condition.patch
@@ -89,26 +89,6 @@ index 05d4042..7006d19 100644
  	}
  
  	/*
-diff --git a/drivers/net/wireless-3.8/brcm80211/brcmfmac/dhd_linux.c b/drivers/net/wireless-3.8/brcm80211/brcmfmac/dhd_linux.c
-index 128161c..d3db8f7 100644
---- a/drivers/net/wireless-3.8/brcm80211/brcmfmac/dhd_linux.c
-+++ b/drivers/net/wireless-3.8/brcm80211/brcmfmac/dhd_linux.c
-@@ -974,13 +974,13 @@ fail:
- 			brcmf_fws_deinit(drvr);
- 		}
- 		if (drvr->iflist[0]) {
--			if (ifp->ndev->destructor == NULL)
-+			if (ifp->ndev->destructor == NULL && ifp->vif)
- 				brcmf_free_vif(ifp->vif);
- 			free_netdev(ifp->ndev);
- 			drvr->iflist[0] = NULL;
- 		}
- 		if (p2p_ifp) {
--			if (p2p_ifp->ndev->destructor == NULL)
-+			if (p2p_ifp->ndev->destructor == NULL && p2p_ifp->vif)
- 				brcmf_free_vif(p2p_ifp->vif);
- 			free_netdev(p2p_ifp->ndev);
- 			drvr->iflist[1] = NULL;
 -- 
 2.4.4
 


### PR DESCRIPTION
* drivers/net/wireless-3.8/mwifiex/main.c seems to be mostly
  due to switch from dev_err() to mwifiex_dbg().

* drivers/net/wireless-3.8/brcm80211/brcmfmac/dhd_linux.c is somewhat
  trickier, as the code switched from brcmf_free_vif+free_netdev to
  brcmf_cfg80211_free_netdev. Not sure if this is correct, but it
  does resolve the patch conflict.