### PR TITLE
Remove libesd0-dev from build-deps.sh

### DIFF
--- a/build-deps.sh
+++ b/build-deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-apt-get install -y git-core gnupg flex bison gperf libesd0-dev build-essential \
+apt-get install -y git-core gnupg flex bison gperf build-essential \
 zip curl libncurses5-dev zlib1g-dev libncurses5-dev gcc-multilib g++-multilib \
 parted kpartx debootstrap pixz qemu-user-static abootimg cgpt vboot-kernel-utils \
 vboot-utils u-boot-tools bc lzma lzop automake autoconf m4 dosfstools rsync \


### PR DESCRIPTION
This package doesn't seem to exist in the Kali apt-get repo's anymore.  I was able to compile rpi0w-nexmon-p4wnp1.sh fine without this package.  Do any of the other build-scripts depend on this package?