### PR TITLE
suggestion for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Offensive Security Kali Linux ARM build scripts are used to build our official K
     •	The cross compilers from our github account is necessary.
     
 For armel images (RPi), use:
+
 https://github.com/offensive-security/gcc-arm-eabi-linaro-4.6.2
 
 For armhf images, use:
+
 https://github.com/offensive-security/gcc-arm-linux-gnueabihf-4.7
 
 For arm64 images (ODROID-C2), use:
+
 https://releases.linaro.org/archive/14.09/components/toolchain/binaries/gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux.tar.xz
 
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 Kali-ARM-Build-Scripts
 ======================
 
-Offensive Security Kali Linux ARM build scripts. We use these to build our official Kali Linux ARM images,
-as can be found at http://www.kali.org/downloads/
+Offensive Security Kali Linux ARM build scripts are used to build our official Kali Linux ARM images which can be found at http://www.kali.org/downloads/
+    •	These scripts have been tested on a Kali Linux 32- and 64-bits installations, after making sure that all the dependencies have been installed.
+    •	Do run the build-deps.sh script first which installs all required dependencies.
+    •	The cross compilers from our github account is necessary.
+    
+For armel images (RPi), use:
+https://github.com/offensive-security/gcc-arm-eabi-linaro-4.6.2
+For armhf images, use:
+https://github.com/offensive-security/gcc-arm-linux-gnueabihf-4.7
+For arm64 images (ODROID-C2), use:
+https://releases.linaro.org/archive/14.09/components/toolchain/binaries/gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux.tar.xz
 
-- These scripts have been tested on a Kali Linux 32 and 64 bit installations only, after making sure
-that all the dependencies have been installed.
-- Make sure you run the build-deps.sh script first, which installs all required dependencies.
-
-- You will need to use the cross compilers from our github account.
-
-armel images (RPi) will use https://github.com/offensive-security/gcc-arm-eabi-linaro-4.6.2
-
-armhf images will use https://github.com/offensive-security/gcc-arm-linux-gnueabihf-4.7
-
-arm64 images (ODROID-C2) will use https://releases.linaro.org/archive/14.09/components/toolchain/binaries/gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux.tar.xz
 
 A sample workflow would look similar to (armhf):
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@ Kali-ARM-Build-Scripts
 ======================
 
 Offensive Security Kali Linux ARM build scripts are used to build our official Kali Linux ARM images which can be found at http://www.kali.org/downloads/
+
     •	These scripts have been tested on a Kali Linux 32- and 64-bits installations, after making sure that all the dependencies have been installed.
     •	Do run the build-deps.sh script first which installs all required dependencies.
     •	The cross compilers from our github account is necessary.
     
 For armel images (RPi), use:
 https://github.com/offensive-security/gcc-arm-eabi-linaro-4.6.2
+
 For armhf images, use:
 https://github.com/offensive-security/gcc-arm-linux-gnueabihf-4.7
+
 For arm64 images (ODROID-C2), use:
 https://releases.linaro.org/archive/14.09/components/toolchain/binaries/gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux.tar.xz
 


### PR DESCRIPTION
Revision:
Offensive Security Kali Linux ARM build scripts are used to build our official Kali Linux ARM images which can be found at http://www.kali.org/downloads/
•	These scripts have been tested on a Kali Linux 32- and 64-bits installations, after making sure that all the dependencies have been installed.
•	Do run the build-deps.sh script first which installs all required dependencies.
•	The cross compilers from our github account is necessary.
For armel images (RPi), use:
https://github.com/offensive-security/gcc-arm-eabi-linaro-4.6.2
For armhf images, use:
https://github.com/offensive-security/gcc-arm-linux-gnueabihf-4.7
For arm64 images (ODROID-C2), use:
https://releases.linaro.org/archive/14.09/components/toolchain/binaries/gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux.tar.xz

New layout has been applied and some sentences has been re-phrased for clarification purpose.
updated #156 